### PR TITLE
Fixing get_ram() 

### DIFF
--- a/R/clean_ram_output.R
+++ b/R/clean_ram_output.R
@@ -41,5 +41,5 @@ clean_solaris_ram = function(ram) {
 clean_win_ram = function(ram) {
   ram = remove_white(ram)
   ram = ram[nchar(ram) > 0]
-  sum(as.numeric(ram))
+  sum(as.numeric(ram), na.rm=T)
 }

--- a/R/clean_ram_output.R
+++ b/R/clean_ram_output.R
@@ -10,7 +10,7 @@ to_bytes = function(value) {
 }
 
 clean_ram = function(ram, os) {
-  if (length(ram) > 1 || is.na(ram)) return(NA)
+  if (length(ram) > 1 && is.na(ram)) return(NA)
 
   if (length(grep("^linux", os))) {
     clean_ram = clean_linux_ram(ram)
@@ -41,5 +41,5 @@ clean_solaris_ram = function(ram) {
 clean_win_ram = function(ram) {
   ram = remove_white(ram)
   ram = ram[nchar(ram) > 0]
-  sum(as.numeric(ram), na.rm=T)
+  sum(as.numeric(ram))
 }

--- a/R/get_ram.R
+++ b/R/get_ram.R
@@ -77,18 +77,18 @@ get_ram = function() {
 }
 
 #' @rawNamespace S3method(print,ram)
-print.ram = function(x, digits = 3, unit_system = c("metric", "iec"), ...) {
+print.ram = function(x, digits = 3, unit_system = c("iec", "metric"), ...) {
   unit_system = match.arg(unit_system)
   #unit_system = "metric"
-  base = switch(unit_system, iec = 1000, metric = 1024)
+  base = switch(unit_system, metric = 1000, iec = 1024)
   power = min(floor(log(abs(x), base)), 8)
   if (is.na(x) || power < 1) {
     unit = "B"
   } else {
     unit_labels = switch(
       unit_system,
-      metric = c("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
-      iec = c("KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
+      iec = c("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
+      metric = c("KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
     )
     unit = unit_labels[[power]]
     x = x / (base^power)

--- a/R/get_ram.R
+++ b/R/get_ram.R
@@ -80,7 +80,7 @@ get_ram = function() {
 print.ram = function(x, digits = 3, unit_system = c("metric", "iec"), ...) {
   unit_system = match.arg(unit_system)
   #unit_system = "metric"
-  base = switch(unit_system, metric = 1000, iec = 1024)
+  base = switch(unit_system, iec = 1000, metric = 1024)
   power = min(floor(log(abs(x), base)), 8)
   if (is.na(x) || power < 1) {
     unit = "B"

--- a/R/get_ram.R
+++ b/R/get_ram.R
@@ -87,8 +87,8 @@ print.ram = function(x, digits = 3, unit_system = c("iec", "metric"), ...) {
   } else {
     unit_labels = switch(
       unit_system,
-      iec = c("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
-      metric = c("KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
+      metric = c("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
+      iec = c("KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
     )
     unit = unit_labels[[power]]
     x = x / (base^power)


### PR DESCRIPTION
The current changes give an appropriate RAM value in Windows 10/11; earlier, it gave "NA B".

My session info - 
R version 4.1.2 (2021-11-01)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 22000)

Two RAM slots - one in use (8GB); the other is empty.