### PR TITLE
Improve clean_win_ram function for better handling of non-numeric values on Windows machines

### DIFF
--- a/R/clean_ram_output.R
+++ b/R/clean_ram_output.R
@@ -44,5 +44,12 @@ clean_darwin_ram = function(ram) {
 }
 
 clean_win_ram = function(ram) {
-  sum(as.numeric(ram))
+  # Remove empty or non-numeric entries
+  ram = ram[!is.na(as.numeric(ram))]
+
+  # Sum the valid numeric entries
+  total_ram = sum(as.numeric(ram), na.rm = TRUE)
+
+  # Return the total RAM
+  return(total_ram)
 }


### PR DESCRIPTION
### Description:
These changes directly fix #49 and #54, where get_ram() fails on Windows machines because of improper handling of non-numeric values in the clean_win_ram function. 

### Error:
The error encountered was:

`Error in inherits(ram, "try-error") || length(ram) == 0L || is.na(ram) : 
  'length = 9' in coercion to 'logical(1)'`

### Changes Made:

- Updated clean_win_ram function to remove empty or non-numeric entries.
- Ensured clean_win_ram function sums only valid numeric entries.

These changes ensure that the clean_win_ram function correctly processes the RAM values on windows machines, preventing the error and allowing get_ram() to function as expected.
